### PR TITLE
Изменения для работы на новых версиях VK (Предположительно 6.54 и выше)

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -223,7 +223,8 @@ func (p *Proxy) prepareProxyRequest(ctx *fasthttp.RequestCtx, replaceContext *re
 			!strings.HasSuffix(endpoint, ".vk.com") &&
 			!strings.HasSuffix(endpoint, ".vkuseraudio.net") &&
 			!strings.HasSuffix(endpoint, ".vkuseraudio.com") &&
-			!strings.HasSuffix(endpoint, ".mycdn.me"){
+			!strings.HasSuffix(endpoint, ".mycdn.me") &&
+			endpoint != "api.ok.ru" {
 			return false
 		}
 		host = endpoint


### PR DESCRIPTION
Изменение полей в oauth.vk.com позволит пройти авторизацию в "VK ID" и прочих внутренних разделах VKUI.
Также, добавление api.ok.ru в белый список позволит звонить через новые версии VK, так как звонки 2.0 используют сервера OK и MyCDN.